### PR TITLE
Fix tests failing for Windows learners

### DIFF
--- a/TechJobsOO.Tests/TechJobsOO.Tests.csproj
+++ b/TechJobsOO.Tests/TechJobsOO.Tests.csproj
@@ -19,4 +19,12 @@
     <ProjectReference Include="..\TechJobsOOAutoGraded6\TechJobsOOAutoGraded6.csproj" />
     <ProjectReference Include="..\TechJobs.Test\TechJobs.Tests.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="StartsAndEndsWithNewLine.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="EmptyFieldTest.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/TechJobsOO.Tests/TestTask2.cs
+++ b/TechJobsOO.Tests/TestTask2.cs
@@ -11,7 +11,7 @@ namespace TechJobsOO.Tests
         /* TODO: Task 2: Remove this line to uncomment the tests
 
         [TestMethod] //1
-        public void Test_Second_Location_Constructor_Exists()
+        public void Test01_Second_Location_Constructor_Exists()
         {
             Type locType = typeof(Location);
             ConstructorInfo[] constructorInfos = locType.GetConstructors();
@@ -40,7 +40,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //2
-        public void Test_Second_Location_Constructor_Initializes_Value()
+        public void Test02_Second_Location_Constructor_Initializes_Value()
         {
             //setup
             Location testLocation = new Location("Desert");
@@ -52,7 +52,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //3
-        public void Test_Second_Location_Constructor_Initializes_Id()
+        public void Test03_Second_Location_Constructor_Initializes_Id()
         {
             //setup
             Location testLocation = new Location("Desert");
@@ -67,7 +67,7 @@ namespace TechJobsOO.Tests
         // Testing CoreCompetency --------------------------------------------------------
 
         [TestMethod] //4
-        public void Test_CoreCompetency_Accessor_SetUp()
+        public void Test04_CoreCompetency_Accessor_SetUp()
         {
             //setup
             CoreCompetency testComp = new CoreCompetency("Persistence");
@@ -94,7 +94,7 @@ namespace TechJobsOO.Tests
         }
 
         [TestMethod] //5
-        public void Test_CoreCompetency_Has_No_Id_Setter_SetUp()
+        public void Test05_CoreCompetency_Has_No_Id_Setter_SetUp()
         {
             Type ccType = typeof(CoreCompetency);
             MemberInfo[] memberInfos = ccType.GetMembers();
@@ -119,7 +119,7 @@ namespace TechJobsOO.Tests
         // Testing PositionType --------------------------------------------------------
 
         [TestMethod] //6
-        public void Test_PositionType_Equals_Method_SetUp()
+        public void Test06_PositionType_Equals_Method_SetUp()
         {
             // set up
             PositionType testPosition = new PositionType("Quality Control");
@@ -143,7 +143,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //7
-        public void Test_PositionType_HashCode_SetUp()
+        public void Test07_PositionType_HashCode_SetUp()
         {
             // set up
             PositionType testPosition = new PositionType("Quality Control");
@@ -162,7 +162,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //8
-        public void Test_PositionType_ToString_SetUp()
+        public void Test08_PositionType_ToString_SetUp()
         {
             //setup
             PositionType testPosition = new PositionType("Quality Control");

--- a/TechJobsOO.Tests/TestTask3.cs
+++ b/TechJobsOO.Tests/TestTask3.cs
@@ -10,7 +10,7 @@ namespace TechJobsOO.Tests
           
      
         [TestMethod]    //1
-        public void Test_JobClass_Has_No_Arg_Constructor()
+        public void Test01_JobClass_Has_No_Arg_Constructor()
         {
             Type jobType = typeof(Job);
             ConstructorInfo[] constructorInfos = jobType.GetConstructors();
@@ -38,7 +38,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //2
-        public void Test_No_Arg_Constructor_Sets_Unique_Id()
+        public void Test02_No_Arg_Constructor_Sets_Unique_Id()
         {
             Job testJob1 = new Job();
             Job testJob2 = new Job();
@@ -48,7 +48,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod]  //3
-        public void Test_JobClass_Has_Second_Constructror()
+        public void Test03_JobClass_Has_Second_Constructror()
         {
             //setup
             Type jobType = typeof(Job);
@@ -77,7 +77,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //4
-        public void Test_JobClass_Has_Accessors()
+        public void Test04_JobClass_Has_Accessors()
         {
             //setup
             Job testJob1 = new Job("Product tester", new Employer("ACME"), new Location("Desert"), new PositionType("Quality control"), new CoreCompetency("Persistence"));
@@ -94,7 +94,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //5
-        public void Test_Equals_Method_Setup()
+        public void Test05_Equals_Method_Setup()
         {
             //setup
             Job testJob1 = new Job("Product tester", new Employer("ACME"), new Location("Desert"), new PositionType("Quality control"), new CoreCompetency("Persistence"));
@@ -116,7 +116,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod]  //6
-        public void Test_GetHashCode_Setup()
+        public void Test06_GetHashCode_Setup()
         {
             //setup
             Job testJob1 = new Job("Product tester", new Employer("ACME"), new Location("Desert"), new PositionType("Quality control"), new CoreCompetency("Persistence"));

--- a/TechJobsOO.Tests/TestTask4.cs
+++ b/TechJobsOO.Tests/TestTask4.cs
@@ -9,7 +9,7 @@ namespace TechJobsOO.Tests
         /* TODO: Task 4: Remove this line to uncomment the tests
 
         [TestMethod] //1
-        public void Test_TestSettingJobIdExists()
+        public void Test01_TestSettingJobIdExists()
         {
             //setup
             Type testType = typeof(JobTests);
@@ -32,7 +32,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //2
-        public void Test_TestJobConstructorSetsAllFields()
+        public void Test02_TestJobConstructorSetsAllFields()
         {
             Type testType = typeof(JobTests);
             MemberInfo[] memberInfos = testType.GetMembers();
@@ -54,7 +54,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //3
-        public void Test_TestJobsForEquality()
+        public void Test03_TestJobsForEquality()
         {
             Type testType = typeof(JobTests);
             MemberInfo[] memberInfos = testType.GetMembers();

--- a/TechJobsOO.Tests/TestTask5.cs
+++ b/TechJobsOO.Tests/TestTask5.cs
@@ -1,4 +1,5 @@
-﻿
+using System.Text.RegularExpressions;
+
 namespace TechJobsOO.Tests
 {
 	[TestClass]
@@ -62,7 +63,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod]  //3
-        public void Test03_ToStringContainsCorrectLabelsAndData_Exists()
+        public void Test03_TestToStringContainsCorrectLabelsAndData_Exists()
         {
             //test to verify that TestToStringContainsCorrectLabelsAndData exisits
 
@@ -147,7 +148,7 @@ namespace TechJobsOO.Tests
             var outputLines = Regex.Split(output, "\r\n|\r|\n");
 
             //verify
-            CollectionAssert.AreEqual(text, output, "Empty string handling error");
+            CollectionAssert.AreEqual(textLines, outputLines, "Empty string handling error");
         }
         TODO: Task 5: Remove this line to uncomment the tests*/
 

--- a/TechJobsOO.Tests/TestTask5.cs
+++ b/TechJobsOO.Tests/TestTask5.cs
@@ -14,7 +14,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod]  //1
-        public void TestToStringStartsAndEndsWithNewLineExists()
+        public void Test01_TestToStringStartsAndEndsWithNewLineExists()
         {
             //test to verify that TestToStringStartsAndEndsWithNewLine exisits
 
@@ -39,7 +39,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod]  //2
-        public void Test_TestToString_Starts_And_Ends_With_NewLine()
+        public void Test02_TestToString_Starts_And_Ends_With_NewLine()
         {
             //comparing output to a text file.
             //id numbers may get a little wonky
@@ -51,16 +51,18 @@ namespace TechJobsOO.Tests
             var job = new RunTechJobs();
             job.RunProgram();
             var output = stringWriter.ToString();
+            var textLines = Regex.Split(text, "\r\n|\r|\n");
+            var outputLines = Regex.Split(output, "\r\n|\r|\n");
 
             //verify
-            Assert.AreEqual(text, output, "New Line issue");
+            CollectionAssert.AreEqual(textLines, outputLines, "New Line issue");
         }
 
         //Unit Test 2: TestToStringContainsCorrectLabelsAndData -----------------------
 
 
         [TestMethod]  //3
-        public void TestToStringContainsCorrectLabelsAndData_Exists()
+        public void Test03_ToStringContainsCorrectLabelsAndData_Exists()
         {
             //test to verify that TestToStringContainsCorrectLabelsAndData exisits
 
@@ -85,7 +87,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod]  //4
-        public void Test_TestToStringContainsCorrectLabelsAndData()
+        public void Test04_TestToStringContainsCorrectLabelsAndData()
         {
             //comparing output to a text file.
             //id numbers may get a little wonky
@@ -105,7 +107,7 @@ namespace TechJobsOO.Tests
         //Unit Test 3: TestToStringHandlesEmptyField --------------------
 
         [TestMethod] //5
-        public void TestToStringHandlesEmptyField_Exists()
+        public void Test05_TestToStringHandlesEmptyField_Exists()
         {
             //test to verify that TestToStringHandlesEmptyField exisits
             //setup
@@ -130,7 +132,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //6
-        public void Test_TestToStringHandlesEmptyField()
+        public void Test06_TestToStringHandlesEmptyField()
         {
             //comparing output to a text file.
             //id numbers may get a little wonky
@@ -141,9 +143,11 @@ namespace TechJobsOO.Tests
             var job = new RunTechJobs();
             job.RunProgram();
             var output = stringWriter.ToString();
+            var textLines = Regex.Split(text, "\r\n|\r|\n");
+            var outputLines = Regex.Split(output, "\r\n|\r|\n");
 
             //verify
-            Assert.AreEqual(text, output, "Empty string handling error");
+            CollectionAssert.AreEqual(text, output, "Empty string handling error");
         }
         TODO: Task 5: Remove this line to uncomment the tests*/
 

--- a/TechJobsOO.Tests/TestTask6.cs
+++ b/TechJobsOO.Tests/TestTask6.cs
@@ -10,7 +10,7 @@ namespace TechJobsOO.Tests
         /* TODO: Task 6: Remove this line to uncomment the tests
          
         [TestMethod] //1
-        public void Test_Attributes_Of_JobField()
+        public void Test01_Attributes_Of_JobField()
         {
             //setup 
             Type jFType = typeof(JobField);
@@ -22,7 +22,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod]  //2
-        public void Test_DRY_Employer()
+        public void Test02_DRY_Employer()
         {
             //setup
             Type empType = typeof(Employer);
@@ -38,7 +38,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //3
-        public void Test_DRY_Location()
+        public void Test03_DRY_Location()
         {
             //setup
             Type locType = typeof(Location);
@@ -54,7 +54,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //4
-        public void Test_DRY_Position()
+        public void Test04_DRY_Position()
         {
             //setup
             Type posType = typeof(PositionType);
@@ -70,7 +70,7 @@ namespace TechJobsOO.Tests
 
 
         [TestMethod] //5
-        public void Test_DRY_CoreCompetency()
+        public void Test05_DRY_CoreCompetency()
         {
             //setup
             Type ccType = typeof(CoreCompetency);


### PR DESCRIPTION
Tests in TestTask2 and TestTask5 are currently written to require execution in a certain order.  Mac VS2022 runs the methods in the order they are written (the tests are written to expect this execution order), while Windows VS2022 runs the methods in alphabetical order causing some to fail (ID property mismatches).

Additionally, tests 2 and 6 in TestTask5 do not account for differences in line separator between Mac and Windows.  The text files learner's output is being compared to is in Mac/*nix 
 format (\n), causing issues for Windows learners (\r\n).

Also fixes a project setting to copy the test comparison text files into the output folder. 